### PR TITLE
Fix typo

### DIFF
--- a/go/design/error_3.go
+++ b/go/design/error_3.go
@@ -101,5 +101,5 @@ func Unmarshal(data []byte, v interface{}) error {
 // that's gonna create a cascading effect all the way through our code. We are no longer protected
 // by the decoupling of the error interface.
 
-// This sometime has to happen. Can we do something differnt not to lose the decoupling. This is
+// This sometime has to happen. Can we do something different not to lose the decoupling. This is
 // where the idea of behavior as context comes in.

--- a/go/design/error_6.go
+++ b/go/design/error_6.go
@@ -37,7 +37,7 @@ func (c *AppError) Error() string {
 func main() {
 	// Make the function call and validate the error.
 
-	// firtCall calls secondCall calls thirdCall then results in AppError.
+	// firstCall calls secondCall calls thirdCall then results in AppError.
 	// Start down the call stack, in thirdCall, where the error occurs. The is the root of the
 	// error. We return it up the call stack in our traditional error interface value.
 	// Back to secondCall, we get the interface value and there is a concrete type stored inside

--- a/go/design/mocking_2.go
+++ b/go/design/mocking_2.go
@@ -15,7 +15,7 @@ import (
 // publisher is an interface to allow this package to mock the pubsub package.
 // When we are writing our applications, declare our own interface that map out all the APIs call
 // we need for the APIs. The concrete types APIs in the previous files satisfy it out of the box.
-// We can write the entire application with mocking decoupling from conrete implementations.
+// We can write the entire application with mocking decoupling from concrete implementations.
 type publisher interface {
 	Publish(key string, v interface{}) error
 	Subscribe(key string) error

--- a/go/language/constant.go
+++ b/go/language/constant.go
@@ -1,5 +1,5 @@
 // Constant are not variables.
-// Contants have a parallel type system all to themselves. The minimum precision for constant is
+// Constants have a parallel type system all to themselves. The minimum precision for constant is
 // 256 bit. They are considered to be mathematically exact.
 // Constants only exist at complied time.
 
@@ -14,7 +14,7 @@ func main() {
 
 	// Constant can be typed or untyped.
 	// When it is untyped, we consider it as a kind.
-	// They are implicitly converted by the complier.
+	// They are implicitly converted by the compiler.
 
 	// Untyped Constants.
 	const ui = 12345    // kind: integer

--- a/go/language/interface_1.go
+++ b/go/language/interface_1.go
@@ -37,7 +37,7 @@ type reader interface {
 // It is a concrete type because it has the method read below. It is identical to the method in
 // the reader interface. Because of this, we can say the concrete type file implements the reader
 // interface using a value receiver.
-// There is no fancy syntax. The complier can automatically recognize the implementation here.
+// There is no fancy syntax. The compiler can automatically recognize the implementation here.
 
 // ------------
 // Relationship

--- a/go/language/map.go
+++ b/go/language/map.go
@@ -79,7 +79,7 @@ func main() {
 	// This is a second way we can define users. We can use an existing type and use it as a base for
 	// another type. These are two different types. There is no relationship here.
 	// However, when we try use it as a key, like: u := make(map[users]int)
-	// the complier says we cannot use that: "invalid map key type users"
+	// the compiler says we cannot use that: "invalid map key type users"
 	// The reason is: whatever we use for the key, the value must be comparable. We have to use it
 	// in some sort of boolean expression in order for the map to create a hash value for it.
 }

--- a/go/language/method_1.go
+++ b/go/language/method_1.go
@@ -18,7 +18,7 @@ func (u user) notify() {
 }
 
 // changeEmail implements a method with a pointer receiver: u of type pointer user
-// Using the pointer reciever, the method operates on shared access.
+// Using the pointer receiver, the method operates on shared access.
 func (u *user) changeEmail(email string) {
 	u.email = email
 }

--- a/go/language/pointer.go
+++ b/go/language/pointer.go
@@ -86,7 +86,7 @@ func increment2(inc *int) {
 }
 
 // stayOnStack shows how the variable does not escape.
-// Since we know the size of the user value at compiled time, the complier will put this on a stack
+// Since we know the size of the user value at compiled time, the compiler will put this on a stack
 // frame.
 func stayOnStack() user {
 	// In the stayOnStack stack frame, create a value and initialize it.
@@ -152,7 +152,7 @@ func escapeToHeap() *user {
 // cost.
 
 // Because stack can grow, no Goroutine can have a pointer to some other Goroutine stack.
-// There would be too much overhead for complier to keep track of every pointer. The latency will
+// There would be too much overhead for compiler to keep track of every pointer. The latency will
 // be insane.
 // -> The stack for a Goroutine is only for that Goroutine only. It cannot be shared between
 // Goroutine.

--- a/go/language/slice.go
+++ b/go/language/slice.go
@@ -149,7 +149,7 @@ func main() {
 	// The length is slice3 is 2 and capacity is 6.
 	// Parameters are [starting_index : (starting_index + length)]
 	// By looking at the output, we can see that they are sharing the same backing array.
-	// Thes slice headers get to stay on the stack when we use these value semantics. Only the
+	// These slice headers get to stay on the stack when we use these value semantics. Only the
 	// backing array that needed to be on the heap.
 	slice3 := slice2[2:4]
 
@@ -212,7 +212,7 @@ func main() {
 
 	// Append a new value to the slice. This line of code raises a red flag.
 	// We have x is a slice with length 7, capacity 7. Since the length and capacity is the same,
-	// append doubles its size then copy values over. x nows points to diffrent memeory block and
+	// append doubles its size then copy values over. x nows points to different memory block and
 	// has a length of 8, capacity of 14.
 	x = append(x, 800)
 

--- a/go/testing/web_server/handlers/handlers_example_test.go
+++ b/go/testing/web_server/handlers/handlers_example_test.go
@@ -11,7 +11,7 @@
 // our API. More interestingly, Examples are not only for documentation but they can also be tests.
 // For them to be tests, we need to add a comment at the end of the functions: one is Output and
 // one is expected output. If we change the expected output to be something wrong then, the
-// complier will tell us when we run the test. Below is an example.
+// compiler will tell us when we run the test. Below is an example.
 
 // Example tests are really powerful. They give users examples how to use the API and validate that
 // the APIs and examples are working.


### PR DESCRIPTION
use [codespell](https://github.com/codespell-project/codespell) to check & correct spellings